### PR TITLE
Add cloudwatch read permissions for further healtchecks

### DIFF
--- a/cfn/guardduty.template
+++ b/cfn/guardduty.template
@@ -816,6 +816,15 @@
                         "lambda:ListEventSourceMappings"
                      ],
                      "Resource": "*"
+                  },
+                  {
+                     "Effect":"Allow",
+                     "Action":[
+                        "cloudwatch:Get*",
+                        "cloudwatch:Describe*",
+                        "cloudwatch:List*"
+                     ],
+                     "Resource": "*"
                   }
                ]
             }


### PR DESCRIPTION
### Solution Description
We'd like the collector to have access to its CloudWatch metrics in order to monitor them.
Therefore adding CW read permissions into `HealthCheckLambdaPolicy`.
CW doesn't provide any specific resources for [access control](http://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/iam-access-control-overview-cw.html#CloudWatch_ARN_Format), therefore `"Resource": "*"` is used.

### Reviewers
@ikemsley @alexturkin 