### PR TITLE
readme: rename <username> to <email address>

### DIFF
--- a/cfn/README-GD.md
+++ b/cfn/README-GD.md
@@ -40,7 +40,7 @@ In order to verify the user has administrator permissions:
 The following procedure assumes a Linux-based local machine using [curl](https://curl.haxx.se/) and 
 [jq](https://stedolan.github.io/jq/). For Windows please use command line and windows versions of [curl](https://curl.haxx.se/download.html) and [jq](https://stedolan.github.io/jq/download/).
 
-From the bash command line, type the following commands, where `<email address>` is your Alert Logic Cloud Insight email address, and then enter your password when prompted:
+From the bash command line, type the following commands, where `<email address>` is your Alert Logic Cloud Insight email address you use to log in, and then enter your password when prompted:
 
 ```
 export AL_USERNAME='<email address>'


### PR DESCRIPTION
### Problem
In current readme we use word "username", while our UI uses "email address" on Login & Users pages and **does not use "username"**, so the instruction might be confusing.

Login page:
![image](https://user-images.githubusercontent.com/3668455/33182321-7a808708-d06b-11e7-8fe8-86eac46b14fc.png)

Users page:
![image](https://user-images.githubusercontent.com/3668455/33182375-a9a14090-d06b-11e7-8950-7e88b92156d7.png)



### Solution
Rename it to `<email address>`
