### PR TITLE
Use basic lambda policy for GetEndpoints function.

### DIFF
--- a/cfn/guardduty.template
+++ b/cfn/guardduty.template
@@ -78,7 +78,7 @@
             "Type": "AWS::KMS::Key",
             "DependsOn":[
                 "CollectLambdaRole",
-                "BasicLambdaRole",
+                "EncryptLambdaRole",
                 "EndpointAPIs"
             ],
             "Properties": {
@@ -130,7 +130,7 @@
                           "Principal": {
                              "AWS": {
                                 "Fn::GetAtt": [
-                                   "BasicLambdaRole",
+                                   "EncryptLambdaRole",
                                    "Arn"
                                 ]
                              }
@@ -364,7 +364,7 @@
                 "Description":"Alert Logic Lambda Encrypt function",
                 "Role":{
                     "Fn::GetAtt":[
-                        "BasicLambdaRole",
+                        "EncryptLambdaRole",
                         "Arn"
                     ]
                 },
@@ -435,7 +435,7 @@
             "DependsOn": [
                 "LambdaKmsKey",
                 "EncryptLambdaFunction",
-                "BasicLambdaPolicy"
+                "EncryptLambdaPolicy"
             ],
             "Properties": {
                 "ServiceToken": {

--- a/cfn/guardduty.template
+++ b/cfn/guardduty.template
@@ -186,7 +186,6 @@
             "Type":"AWS::IAM::Policy",
             "DependsOn":[
                 "BasicLambdaRole",
-                "EncryptLambdaFunction",
                 "GetEndpointsLambdaFunction"
             ],
             "Properties":{
@@ -203,26 +202,6 @@
                             "Effect":"Allow",
                             "Action":"logs:CreateLogGroup",
                             "Resource":[
-                                {
-                                    "Fn::Join":[
-                                        "",
-                                        [
-                                            "arn:aws:logs:",
-                                            {
-                                                "Ref":"AWS::Region"
-                                            },
-                                            ":",
-                                            {
-                                                "Ref":"AWS::AccountId"
-                                            },
-                                            ":log-group:/aws/lambda/",
-                                            {
-                                                "Ref":"EncryptLambdaFunction"
-                                            },
-                                            ":*"
-                                        ]
-                                    ]
-                                },
                                 {
                                     "Fn::Join":[
                                         "",
@@ -266,12 +245,89 @@
                                             },
                                             ":log-group:/aws/lambda/",
                                             {
-                                                "Ref":"EncryptLambdaFunction"
+                                                "Ref":"GetEndpointsLambdaFunction"
                                             },
                                             ":log-stream:*"
                                         ]
                                     ]
-                                },
+                                }
+                            ]
+                        }
+                    ]
+                }
+            }
+        },
+        "EncryptLambdaRole":{
+            "Type":"AWS::IAM::Role",
+            "Properties":{
+                "Path":"/",
+                "AssumeRolePolicyDocument":{
+                    "Version":"2012-10-17",
+                    "Statement":[
+                        {
+                            "Effect":"Allow",
+                            "Principal":{
+                                "Service":[
+                                    "lambda.amazonaws.com"
+                                ]
+                            },
+                            "Action": [
+                                "sts:AssumeRole"
+                            ]
+                        }
+                   ]
+                }
+            }
+        },
+        "EncryptLambdaPolicy":{
+            "Type":"AWS::IAM::Policy",
+            "DependsOn":[
+                "EncryptLambdaRole",
+                "EncryptLambdaFunction"
+            ],
+            "Properties":{
+                "Roles":[
+                   {
+                      "Ref":"EncryptLambdaRole"
+                   }
+                ],
+                "PolicyName":"alertlogic-encrypt-lambda-policy",
+                "PolicyDocument":{
+                    "Version":"2012-10-17",
+                    "Statement":[
+                        {
+                            "Effect":"Allow",
+                            "Action":"logs:CreateLogGroup",
+                            "Resource":[
+                                {
+                                    "Fn::Join":[
+                                        "",
+                                        [
+                                            "arn:aws:logs:",
+                                            {
+                                                "Ref":"AWS::Region"
+                                            },
+                                            ":",
+                                            {
+                                                "Ref":"AWS::AccountId"
+                                            },
+                                            ":log-group:/aws/lambda/",
+                                            {
+                                                "Ref":"EncryptLambdaFunction"
+                                            },
+                                            ":*"
+                                        ]
+                                    ]
+                                }
+                            ]
+                        },
+                        {
+                            "Effect":"Allow",
+                            "Action":[
+                                "logs:CreateLogStream",
+                                "logs:PutLogEvents"
+                            ],
+                            "Resource":[
                                 {
                                    "Fn::Join":[
                                         "",
@@ -286,7 +342,7 @@
                                             },
                                             ":log-group:/aws/lambda/",
                                             {
-                                                "Ref":"GetEndpointsLambdaFunction"
+                                                "Ref":"EncryptLambdaFunction"
                                             },
                                             ":log-stream:*"
                                         ]
@@ -301,7 +357,7 @@
         "EncryptLambdaFunction":{
             "Type":"AWS::Lambda::Function",
             "DependsOn":[
-                "BasicLambdaRole",
+                "EncryptLambdaRole",
                 "EndpointAPIs"
             ],
             "Properties":{
@@ -559,7 +615,7 @@
       "EndpointAPIs": {
         "Type": "AWS::CloudFormation::CustomResource",
          "DependsOn":[
-               "BasicLambdaRole",
+               "BasicLambdaPolicy",
                "GetEndpointsLambdaFunction"
            ],
          "Properties": {

--- a/cfn/guardduty.template
+++ b/cfn/guardduty.template
@@ -78,7 +78,7 @@
             "Type": "AWS::KMS::Key",
             "DependsOn":[
                 "CollectLambdaRole",
-                "EncryptLambdaRole",
+                "BasicLambdaRole",
                 "EndpointAPIs"
             ],
             "Properties": {
@@ -130,7 +130,7 @@
                           "Principal": {
                              "AWS": {
                                 "Fn::GetAtt": [
-                                   "EncryptLambdaRole",
+                                   "BasicLambdaRole",
                                    "Arn"
                                 ]
                              }
@@ -160,7 +160,7 @@
                 ]
             }
         },
-        "EncryptLambdaRole":{
+        "BasicLambdaRole":{
             "Type":"AWS::IAM::Role",
             "Properties":{
                 "Path":"/",
@@ -182,19 +182,20 @@
                 }
             }
         },
-        "EncryptLambdaPolicy":{
+        "BasicLambdaPolicy":{
             "Type":"AWS::IAM::Policy",
             "DependsOn":[
-                "EncryptLambdaRole",
-                "EncryptLambdaFunction"
+                "BasicLambdaRole",
+                "EncryptLambdaFunction",
+                "GetEndpointsLambdaFunction"
             ],
             "Properties":{
                 "Roles":[
                    {
-                      "Ref":"EncryptLambdaRole"
+                      "Ref":"BasicLambdaRole"
                    }
                 ],
-                "PolicyName":"alertlogic-encrypt-lambda-policy",
+                "PolicyName":"alertlogic-basic-lambda-policy",
                 "PolicyDocument":{
                     "Version":"2012-10-17",
                     "Statement":[
@@ -217,6 +218,26 @@
                                             ":log-group:/aws/lambda/",
                                             {
                                                 "Ref":"EncryptLambdaFunction"
+                                            },
+                                            ":*"
+                                        ]
+                                    ]
+                                },
+                                {
+                                    "Fn::Join":[
+                                        "",
+                                        [
+                                            "arn:aws:logs:",
+                                            {
+                                                "Ref":"AWS::Region"
+                                            },
+                                            ":",
+                                            {
+                                                "Ref":"AWS::AccountId"
+                                            },
+                                            ":log-group:/aws/lambda/",
+                                            {
+                                                "Ref":"GetEndpointsLambdaFunction"
                                             },
                                             ":*"
                                         ]
@@ -250,6 +271,26 @@
                                             ":log-stream:*"
                                         ]
                                     ]
+                                },
+                                {
+                                   "Fn::Join":[
+                                        "",
+                                        [
+                                            "arn:aws:logs:",
+                                            {
+                                                "Ref":"AWS::Region"
+                                            },
+                                            ":",
+                                            {
+                                                "Ref":"AWS::AccountId"
+                                            },
+                                            ":log-group:/aws/lambda/",
+                                            {
+                                                "Ref":"GetEndpointsLambdaFunction"
+                                            },
+                                            ":log-stream:*"
+                                        ]
+                                    ]
                                 }
                             ]
                         }
@@ -260,14 +301,14 @@
         "EncryptLambdaFunction":{
             "Type":"AWS::Lambda::Function",
             "DependsOn":[
-                "EncryptLambdaRole",
+                "BasicLambdaRole",
                 "EndpointAPIs"
             ],
             "Properties":{
                 "Description":"Alert Logic Lambda Encrypt function",
                 "Role":{
                     "Fn::GetAtt":[
-                        "EncryptLambdaRole",
+                        "BasicLambdaRole",
                         "Arn"
                     ]
                 },
@@ -338,7 +379,7 @@
             "DependsOn": [
                 "LambdaKmsKey",
                 "EncryptLambdaFunction",
-                "EncryptLambdaPolicy"
+                "BasicLambdaPolicy"
             ],
             "Properties": {
                 "ServiceToken": {
@@ -361,13 +402,13 @@
         "GetEndpointsLambdaFunction": {
           "Type": "AWS::Lambda::Function",
            "DependsOn":[
-               "CollectLambdaRole"
+               "BasicLambdaRole"
            ],
            "Properties": {
                "Handler": "index.handler",
                "Role": {
                    "Fn::GetAtt": [
-                       "CollectLambdaRole",
+                       "BasicLambdaRole",
                        "Arn"
                    ]
                },
@@ -501,7 +542,7 @@
                        ]
                    }
                },
-               "Runtime": "nodejs4.3",
+               "Runtime": "nodejs6.10",
                "Timeout": "60",
                 "Tags": [
                     {

--- a/cfn/guardduty.template
+++ b/cfn/guardduty.template
@@ -559,7 +559,7 @@
       "EndpointAPIs": {
         "Type": "AWS::CloudFormation::CustomResource",
          "DependsOn":[
-               "CollectLambdaRole",
+               "BasicLambdaRole",
                "GetEndpointsLambdaFunction"
            ],
          "Properties": {


### PR DESCRIPTION
### Problem Description
`GetEndpointsLambdaFunction` lacks permissions for creating CW log group. Therefore all all log events for this function are missed which makes it more difficult to trace any invocation issues.

### Solution Description
Introduce `BasicLambdaRole` and `BasicLambdaPolicy` which allows `GetEndpointsLambdaFunction` to create CW logs groups/streams and put log events.

### Reviewers
@andrey-smirnov @ikemsley @tomdos @alexturkin 