### PR TITLE
Add forced update functionality

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ language: node_js
 node_js:
   - "8"
 install:
-  - make deps
+  - npm install
 script:
-  - make test
+  - npm test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "al-cwe-collector",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "license": "MIT",
   "description": "Alert Logic CloudWatch Events Collector",
   "repository": {
@@ -40,7 +40,7 @@
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
     "@alertlogic/al-collector-js": "1.2.4",
-    "@alertlogic/al-aws-collector-js": "1.2.0"
+    "@alertlogic/al-aws-collector-js": "1.3.0"
   },
   "author": "Alert Logic Inc."
 }


### PR DESCRIPTION
This PR updates the dependency for al-aws-collector-js library.

This will add the ability for Alert Logic to tell collectors to update themselves at checkin, rather that at the scheduled update time every 12 hours.