### PR TITLE
update buffer constructor

### DIFF
--- a/cfn/guardduty.template
+++ b/cfn/guardduty.template
@@ -299,7 +299,7 @@
                                 "            console.log(err, err.stack); // an error occurred\n",
                                 "            return response.send(event, context, response.FAILED);\n",
                                 "        }\n",
-                                "        var base64 = new Buffer(data.CiphertextBlob).toString('base64');\n",
+                                "        var base64 = Buffer.from(data.CiphertextBlob).toString('base64');\n",
                                 "        var responseData = {\n",
                                 "            EncryptedText : base64\n",
                                 "        };\n",

--- a/index.js
+++ b/index.js
@@ -27,7 +27,7 @@ function getDecryptedCredentials(callback) {
     } else {
         const kms = new AWS.KMS();
         kms.decrypt(
-            {CiphertextBlob: new Buffer(process.env.aims_secret_key, 'base64')},
+            {CiphertextBlob: Buffer.from(process.env.aims_secret_key, 'base64')},
             (err, data) => {
                 if (err) {
                     return callback(err);
@@ -44,7 +44,7 @@ function getDecryptedCredentials(callback) {
 
 function getKinesisData(event, callback) {
     async.map(event.Records, function(record, mapCallback) {
-        var cwEvent = new Buffer(record.kinesis.data, 'base64').toString('utf-8');
+        var cwEvent = Buffer.from(record.kinesis.data, 'base64').toString('utf-8');
         try {
             return mapCallback(null, JSON.parse(cwEvent));
         } catch (ex) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "al-cwe-collector",
-  "version": "1.3.3",
+  "version": "1.3.4",
   "license": "MIT",
   "description": "Alert Logic CloudWatch Events Collector",
   "repository": {

--- a/test/cwe_test.js
+++ b/test/cwe_test.js
@@ -157,7 +157,7 @@ describe('CWE Unit Tests', function() {
 
         const ACCESS_KEY_ID = 'access_key_id';
         const ENCRYPTED_SECRET_KEY = 'encrypted_secret_key';
-        const ENCRYPTED_SECRET_KEY_BASE64 = new Buffer(ENCRYPTED_SECRET_KEY).toString('base64');
+        const ENCRYPTED_SECRET_KEY_BASE64 = Buffer.from(ENCRYPTED_SECRET_KEY).toString('base64');
         const DECRYPTED_SECRET_KEY = 'secret_key';
 
         before(function() {
@@ -207,7 +207,7 @@ describe('CWE Unit Tests', function() {
             cweRewire.__set__('process', {
                     env : {
                         aims_access_key_id : ACCESS_KEY_ID,
-                        aims_secret_key: new Buffer('wrong_key').toString('base64')
+                        aims_secret_key: Buffer.from('wrong_key').toString('base64')
                     }
             });
             AWS.mock('KMS', 'decrypt', function (data, callback) {


### PR DESCRIPTION
Current use of the `Buffer` constructor is unsafe as support has been deprecated for it.
```The Buffer() and new Buffer() constructors are not recommended for use due to security and usability concerns. Please use the new Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() construction methods instead.```
This led to the above warning appearing on install.

This PR is for migration to `Buffer.from()` in all cases as per these migration guidelines.
https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/#variant-1