### PR TITLE
restrict KMS operations to aims key

### DIFF
--- a/cfn/guardduty.template
+++ b/cfn/guardduty.template
@@ -97,8 +97,13 @@
                              ]
                             }
                             },
-                            "Action": "kms:*",
-                            "Resource": "*"
+                            "Action": [
+                                "kms:Decrypt",
+                                "kms:Encrypt"
+                            ],
+                            "Resource": {
+                                "Ref":"SecretKey"
+                            }
                        },
                        {
                             "Sid": "Allow use of the key for lambda",
@@ -115,7 +120,9 @@
                               "kms:Decrypt",
                               "kms:Encrypt"
                             ],
-                            "Resource": "*"
+                            "Resource": {
+                                "Ref":"SecretKey"
+                            }
                        },
                        {
                           "Sid": "Allow use of the key for lambda encryption",
@@ -131,7 +138,9 @@
                           "Action": [
                              "kms:Encrypt"
                           ],
-                          "Resource": "*"
+                          "Resource": {
+                              "Ref":"SecretKey"
+                          }
                        }
                     ]
                 },

--- a/cfn/guardduty.template
+++ b/cfn/guardduty.template
@@ -102,7 +102,7 @@
                                 "kms:Encrypt"
                             ],
                             "Resource": {
-                                "Ref":"SecretKey"
+                                "*"
                             }
                        },
                        {
@@ -121,7 +121,7 @@
                               "kms:Encrypt"
                             ],
                             "Resource": {
-                                "Ref":"SecretKey"
+                                "*"
                             }
                        },
                        {
@@ -139,7 +139,7 @@
                              "kms:Encrypt"
                           ],
                           "Resource": {
-                              "Ref":"SecretKey"
+                              "*"
                           }
                        }
                     ]


### PR DESCRIPTION
KMS key policy was unnecessarily broad.
Restricting this to only encrypt/decrypt for the AIMS secret key and nothing else