### PR TITLE
ENG-26177: Bump the aws-sdk version to latest to resolve the PackageType issue.

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "al-cwe-collector",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "license": "MIT",
   "description": "Alert Logic CloudWatch Events Collector",
   "repository": {
@@ -21,7 +21,7 @@
     }
   ],
   "devDependencies": {
-    "aws-sdk": "^2.441.0",
+    "aws-sdk": "^2.929.0",
     "aws-sdk-mock": "^4.4.0",
     "dotenv": "^7.0.0",
     "clone": "^2.1.2",


### PR DESCRIPTION
## Problem Description ##
Getting below error while self update configuration event .
`"errorMessage": "{\"message\":\"Unexpected key 'PackageType' found in params\",\"code\":\"UnexpectedParameter\",\"time\":\"2021-06-15T05:38:28.991Z\"}", `

## Root couse ##
The aws-sdk  version is 2.441.0 in package but after npm install it taking latest version(2.927.0) which having the PackageType property but 2.441.0 does not have PackageType property. It's causing the issue .

## Solution ##
PackageType have been introduce after 2.800.0 version  and so we have picked the latest version 2.929.0 .