### PR TITLE
ENG-26177: To fix the packageType issue while self update event

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "al-cwe-collector",
-  "version": "1.3.6",
+  "version": "1.3.7",
   "license": "MIT",
   "description": "Alert Logic CloudWatch Events Collector",
   "repository": {
@@ -40,7 +40,7 @@
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",
     "@alertlogic/al-collector-js": "2.0.4",
-    "@alertlogic/al-aws-collector-js": "4.0.2"
+    "@alertlogic/al-aws-collector-js": "4.0.3"
   },
   "author": "Alert Logic Inc."
 }


### PR DESCRIPTION
Problem Description
In CWE collector with aws-sdk latest version we start getting issue with PackageType while updating config with lambda [updateFunctionConfiguration](https://github.com/alertlogic/al-aws-collector-js/blob/master/al_aws.js#L70)

Solution Description
Added the PackageType in NOUPDATE_CONFIG_PARAMS  of al-aws-collector.js , so that it will delete this param before calling to lambda.UpdateFunctionConfiguration .