### PR TITLE
ENF-26177: Fixed the collector offline issue 

### DIFF
--- a/al-cwe-collector.js
+++ b/al-cwe-collector.js
@@ -72,6 +72,9 @@ class CweCollector extends AlAwsCollector {
             return collector.process(event, asyncCallback);
 
         } else {
+            if (!this.stack_name && event.StackName) {
+                this.stack_name = event.StackName;
+            }
             return super.handleEvent(event);
         }
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "al-cwe-collector",
-  "version": "1.3.7",
+  "version": "1.3.8",
   "license": "MIT",
   "description": "Alert Logic CloudWatch Events Collector",
   "repository": {


### PR DESCRIPTION
## Problem description ##
In CWE with old version of al-aws-collector, they have env variable `process.env.azollect_api` with missing `c` which use to set the azcollect endpoint, but as part of migration we take latest version of al-aws-collector where it  is using the `process.env.azcollect_api` to set azcollect endpoint. 

Some old collector using old KMS key which does not  have access to add the environment variable.So  we are not only able to add `process.env.azcollect_api` but  also not other variables  too in env.  It breaks the azcollect collection as unable to form the correct api url and so stop sending check in event. It result into collector went offline. 

## Solution Description ##
1. We assigned  value of process.env.azollect_api  to  process.env.azcollect_api  for making azcollect connection again.
2. Due to KMS permission issue we also not able to add collector id in env variable ,so set the value to `NA` to avoid make api call in every checkin event.