### PR TITLE
Corrected the StackName used to get cloud formation stack status

### DIFF
--- a/index.js
+++ b/index.js
@@ -172,7 +172,7 @@ exports.handler = function(event, context) {
                 formatMessages,
                 [m_checkin.checkHealth(event, context),
                     function (asyncCallback) {
-                        m_healthChecks.checkCloudFormationStatus(event.stack_name, asyncCallback);
+                        m_healthChecks.checkCloudFormationStatus(event.StackName, asyncCallback);
                     }
                 ],
                 getStatisticsFunctions(event)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "al-cwe-collector",
-  "version": "1.3.12",
+  "version": "1.3.13",
   "license": "MIT",
   "description": "Alert Logic CloudWatch Events Collector",
   "repository": {


### PR DESCRIPTION
**Problem Description:**
Health checks are failed and return error`authorized to perform: cloudformation:DescribeStacks because no identity-based policy allows the cloudformation:DescribeStacks action\",\"code\":\"AccessDenied\` .
cloudformation:DescribeStacks getting first paramer value undefined. so it failed .

**Solution Description:**
Updated to correct variable name to get stack name value.