### PR TITLE
Set CFN CustomResources timeout to 5 min

### DIFF
--- a/cfn/guardduty.template
+++ b/cfn/guardduty.template
@@ -404,7 +404,8 @@
                 },
                 "Plaintext": {
                     "Ref": "SecretKey"
-                }
+                },
+                "Timeout": 300
             }
         },
       "CollectLambdaFunction":{
@@ -940,7 +941,8 @@
             "ServiceToken": { "Fn::GetAtt" : ["CollectLambdaFunction", "Arn"] },
             "StackName": { "Ref" : "AWS::StackName" },
             "AwsAccountId": { "Ref": "AWS::AccountId"},
-            "CollectRule": "aws.guardduty"
+            "CollectRule": "aws.guardduty",
+            "Timeout": 300
          }
       }
    }


### PR DESCRIPTION
### Problem
By default CloudFormation will wait for 1hr for a response from a CustomResource before timing out. In some cases, such as when the user performing an operation on the stack doesn't have all the required permissions to perform the operation, this can lead to long waits before the operation can be retried.

### Solution
Explicitly set a timeout of 5 minutes for both CustomResources