### PR TITLE
Bumped al-aws-collector-js version to 4.1.28 and al-collector-js version to 3.0.14

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "al-cwe-collector",
-  "version": "1.3.27",
+  "version": "1.3.28",
   "license": "MIT",
   "description": "Alert Logic CloudWatch Events Collector",
   "repository": {
@@ -38,8 +38,8 @@
     "sinon": "^18.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "^4.1.27",
-    "@alertlogic/al-collector-js": "^3.0.13",
+    "@alertlogic/al-aws-collector-js": "^4.1.28",
+    "@alertlogic/al-collector-js": "^3.0.14",
     "async": "^3.2.5",
     "cfn-response": "^1.0.1",
     "debug": "^4.3.5",


### PR DESCRIPTION
Bumped al-aws-collector-js version to 4.1.28 and al-collector-js version to 3.0.14
https://github.com/alertlogic/al-aws-collector-js/pull/106