### PR TITLE
[cwe-collector]Npm packages updated for vulnerability fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "al-cwe-collector",
-  "version": "1.3.28",
+  "version": "1.3.29",
   "license": "MIT",
   "description": "Alert Logic CloudWatch Events Collector",
   "repository": {
@@ -21,28 +21,28 @@
     }
   ],
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.609.0",
-    "@aws-sdk/client-cloudwatch": "^3.609.0",
-    "@aws-sdk/client-cloudwatch-events": "^3.609.0",
-    "@aws-sdk/client-kms": "^3.609.0",
-    "@aws-sdk/client-lambda": "^3.609.0",
-    "@aws-sdk/client-s3": "^3.609.0",
-    "@aws-sdk/client-ssm": "^3.609.0",
+    "@aws-sdk/client-cloudformation": "^3.775.0",
+    "@aws-sdk/client-cloudwatch": "^3.775.0",
+    "@aws-sdk/client-cloudwatch-events": "^3.775.0",
+    "@aws-sdk/client-kms": "^3.775.0",
+    "@aws-sdk/client-lambda": "^3.775.0",
+    "@aws-sdk/client-s3": "^3.775.0",
+    "@aws-sdk/client-ssm": "^3.775.0",
     "clone": "^2.1.2",
-    "dotenv": "^16.4.5",
+    "dotenv": "^16.4.7",
     "jshint": "^2.13.6",
-    "mocha": "^10.6.0",
+    "mocha": "^10.8.2",
     "mocha-jenkins-reporter": "^0.4.8",
-    "nyc": "^17.0.0",
+    "nyc": "^17.1.0",
     "rewire": "^7.0.0",
-    "sinon": "^18.0.1"
+    "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "^4.1.28",
-    "@alertlogic/al-collector-js": "^3.0.14",
-    "async": "^3.2.5",
+    "@alertlogic/al-aws-collector-js": "^4.1.29",
+    "@alertlogic/al-collector-js": "^3.0.15",
+    "async": "^3.2.6",
     "cfn-response": "^1.0.1",
-    "debug": "^4.3.5",
+    "debug": "^4.4.0",
     "moment": "^2.30.1"
   },
   "author": "Alert Logic Inc."


### PR DESCRIPTION
### Problem Description
Update the Dependancy due to which below vulnerability are found :
Customer had provided 4 vulnerabilities that they have detected against the GuardDuty Collector
CVEs:
CVE-2024-21538
CVE-2024-57965
CVE-2025-27152
CVE-2025-27789


### Solution Description
npm packages are updated to fix above CVEs

1    "@aws-sdk/client-cloudformation": "^3.775.0",
2    "@aws-sdk/client-cloudwatch": "^3.775.0",
3    "@aws-sdk/client-cloudwatch-events": "^3.775.0",
4    "@aws-sdk/client-kms": "^3.775.0",
5    "@aws-sdk/client-lambda": "^3.775.0",
6    "@aws-sdk/client-s3": "^3.775.0",
7    "@aws-sdk/client-ssm": "^3.775.0",
8    "dotenv": "^16.4.7",
9    "mocha": "^10.8.2",
10    "nyc": "^17.1.0",
11    "sinon": "^20.0.0"
12    "@alertlogic/al-aws-collector-js": "^4.1.29",
13    "@alertlogic/al-collector-js": "^3.0.15",
14    "async": "^3.2.6",
15    "debug": "^4.4.0"
