### PR TITLE
Update NodeJS version to 22 and fix Vulnerabilities reported by AWS inspector

### DIFF
--- a/al-cwe-collector.json
+++ b/al-cwe-collector.json
@@ -1,6 +1,6 @@
 {
     "Runtime": {
         "path": "Runtime",
-        "value": "nodejs20.x"
+        "value": "nodejs22.x"
     }
 }

--- a/cfn/guardduty.template
+++ b/cfn/guardduty.template
@@ -369,7 +369,7 @@
                   }
                 },
                 "Handler":"index.handler",
-                "Runtime":"nodejs20.x",
+                "Runtime":"nodejs22.x",
                 "MemorySize":128,
                 "Timeout": 5,
                 "Tags": [
@@ -439,7 +439,7 @@
                "S3Key": "packages/lambda/al-cwe-collector.zip"
             },
             "Handler":"index.handler",
-            "Runtime":"nodejs20.x",
+            "Runtime":"nodejs22.x",
             "MemorySize":128,
             "Timeout":300,
             "Environment":{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "al-cwe-collector",
-  "version": "1.3.29",
+  "version": "1.3.30",
   "license": "MIT",
   "description": "Alert Logic CloudWatch Events Collector",
   "repository": {
@@ -29,20 +29,20 @@
     "@aws-sdk/client-s3": "^3.775.0",
     "@aws-sdk/client-ssm": "^3.775.0",
     "clone": "^2.1.2",
-    "dotenv": "^16.4.7",
+    "dotenv": "^17.2.1",
     "jshint": "^2.13.6",
     "mocha": "^10.8.2",
     "mocha-jenkins-reporter": "^0.4.8",
     "nyc": "^17.1.0",
-    "rewire": "^7.0.0",
+    "rewire": "^9.0.1",
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "^4.1.29",
-    "@alertlogic/al-collector-js": "^3.0.15",
+    "@alertlogic/al-aws-collector-js": "^4.1.30",
+    "@alertlogic/al-collector-js": "^3.0.16",
     "async": "^3.2.6",
     "cfn-response": "^1.0.1",
-    "debug": "^4.4.0",
+    "debug": "^4.4.1",
     "moment": "^2.30.1"
   },
   "author": "Alert Logic Inc."

--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -8,7 +8,7 @@ stages:
             - pull_request
             - pull_request:
                 trigger_phrase: test it
-        image: node:20
+        image: node:22
         compute_size: small
         commands:
             - npm install 
@@ -17,7 +17,7 @@ stages:
         name: When Tag Created Run Coverage
         when:
             - tag: ['v?\d+.\d+.\d+']
-        image: node:20
+        image: node:22
         compute_size: small
         commands:
             - npm install


### PR DESCRIPTION
### Problem Description
Update NodeJS version to 22 and fix Vulnerabilities reported by AWS inspector 

### Solution Description
Fixed by bumping npm packages versions
"debug": "^4.4.1",
"rewire": "^9.0.1"
"@alertlogic/al-aws-collector-js": "^4.1.30",
"@alertlogic/al-collector-js": "^3.0.16",
"debug": "^4.4.1",
and updated node js to 22 version
