### PR TITLE
Update axios npm package to 1.12.2 latest version and bumped version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "al-cwe-collector",
-  "version": "1.3.30",
+  "version": "1.3.31",
   "license": "MIT",
   "description": "Alert Logic CloudWatch Events Collector",
   "repository": {
@@ -38,8 +38,8 @@
     "sinon": "^20.0.0"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "^4.1.30",
-    "@alertlogic/al-collector-js": "^3.0.16",
+    "@alertlogic/al-aws-collector-js": "^4.1.31",
+    "@alertlogic/al-collector-js": "^3.0.17",
     "async": "^3.2.6",
     "cfn-response": "^1.0.1",
     "debug": "^4.4.1",


### PR DESCRIPTION
### Problem Description
Update axios package to 1.12.2 latest version


### Solution Description
Updated axios package version to 1.12.2 to resolve [CVE-2025-58754](https://nvd.nist.gov/vuln/detail/CVE-2025-58754)
Bumped al-aws-collector-js and al-collector-js
