### PR TITLE
NPM vulnerabilities fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "al-cwe-collector",
-  "version": "1.3.31",
+  "version": "1.3.32",
   "license": "MIT",
   "description": "Alert Logic CloudWatch Events Collector",
   "repository": {
@@ -11,7 +11,7 @@
   "scripts": {
     "start": "node index.js",
     "lint": "jshint --exclude \"./node_modules/*\" **/*.js",
-    "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=cobertura --reporter=text mocha --colors --reporter mocha-jenkins-reporter"
+    "test": "JUNIT_REPORT_PATH=./test/report.xml nyc --reporter=cobertura --reporter=text mocha --colors"
   },
   "main": "index.js",
   "maintainers": [
@@ -21,28 +21,27 @@
     }
   ],
   "devDependencies": {
-    "@aws-sdk/client-cloudformation": "^3.775.0",
-    "@aws-sdk/client-cloudwatch": "^3.775.0",
-    "@aws-sdk/client-cloudwatch-events": "^3.775.0",
-    "@aws-sdk/client-kms": "^3.775.0",
-    "@aws-sdk/client-lambda": "^3.775.0",
-    "@aws-sdk/client-s3": "^3.775.0",
-    "@aws-sdk/client-ssm": "^3.775.0",
+    "@aws-sdk/client-cloudformation": "^3.968.0",
+    "@aws-sdk/client-cloudwatch": "^3.968.0",
+    "@aws-sdk/client-cloudwatch-events": "^3.968.0",
+    "@aws-sdk/client-kms": "^3.968.0",
+    "@aws-sdk/client-lambda": "^3.968.0",
+    "@aws-sdk/client-s3": "^3.968.0",
+    "@aws-sdk/client-ssm": "^3.968.0",
     "clone": "^2.1.2",
-    "dotenv": "^17.2.1",
+    "dotenv": "^17.2.3",
     "jshint": "^2.13.6",
-    "mocha": "^10.8.2",
-    "mocha-jenkins-reporter": "^0.4.8",
+    "mocha": "^11.7.5",
     "nyc": "^17.1.0",
     "rewire": "^9.0.1",
-    "sinon": "^20.0.0"
+    "sinon": "^21.0.1"
   },
   "dependencies": {
-    "@alertlogic/al-aws-collector-js": "^4.1.31",
-    "@alertlogic/al-collector-js": "^3.0.17",
+    "@alertlogic/al-aws-collector-js": "^4.1.32",
+    "@alertlogic/al-collector-js": "^3.0.19",
     "async": "^3.2.6",
     "cfn-response": "^1.0.1",
-    "debug": "^4.4.1",
+    "debug": "^4.4.3",
     "moment": "^2.30.1"
   },
   "author": "Alert Logic Inc."


### PR DESCRIPTION
### Problem Description
Vulnerability [CVE-2025-64718 ](https://github.com/advisories/GHSA-mh29-5h37-fv8m) found in CWE collector in js-yaml package by AWS inspector

### Solution Description
- Upgrade AWS SDK client packages from 3.775.0 to 3.968.0
  - @aws-sdk/client-cloudformation
  - @aws-sdk/client-cloudwatch
  - @aws-sdk/client-kms
  - @aws-sdk/client-lambda
  - @aws-sdk/client-s3
- Update dev dependencies:
  - dotenv: 17.2.1 -> 17.2.3
  - mocha: 10.8.2 -> 11.7.5
  - sinon: 20.0.0 -> 21.0.1
- Update dependencies:
  - @alertlogic/al-collector-js: ^3.0.17 -> ^3.0.19
  - @alertlogic/al-collector-js: ^4.1.31 -> ^4.1.32
  - debug: ^4.4.1 -> ^4.4.3
- removed `mocha-jenkins-reporter` package as it is not used anywhere.