### PR TITLE
vulnerability GHSA-73rr-hh4g-fpgx fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "al-cwe-collector",
-  "version": "1.3.33",
+  "version": "1.3.34",
   "license": "MIT",
   "description": "Alert Logic CloudWatch Events Collector",
   "repository": {
@@ -43,6 +43,9 @@
     "cfn-response": "^1.0.1",
     "debug": "^4.4.3",
     "moment": "^2.30.1"
+  },
+  "overrides": {
+    "diff": "^8.0.3"
   },
   "author": "Alert Logic Inc."
 }


### PR DESCRIPTION
### Problem Description

CWE collector have  dependency on the `diff` (jsdiff) package with versions vulnerable to (https://github.com/advisories/GHSA-73rr-hh4g-fpgx). This vulnerability allows a Denial of Service attack through parsePatch and applyPatch methods when processing patches with specific line break characters (\r, \u2028, or \u2029), potentially causing infinite loops and memory exhaustion.
The `diff` package is coming from ` "mocha": "^11.7.5"`

### Solution Description

Added npm overrides to package.json to force all instances of the `diff` package to use version 8.0.3 or higher, which includes the security patch. This approach allows fixing the vulnerability without directly updating or modifying existing dependencies, ensuring compatibility while addressing the security concern.