### PR TITLE
nvm use 22 nodejs when creating tag as build is failing with ESM errors

### DIFF
--- a/ps_spec.yml
+++ b/ps_spec.yml
@@ -36,7 +36,7 @@ stages:
         image: 422372788747.dkr.ecr.us-east-1.amazonaws.com/al-paws-collector-pipeline:latest
         compute_size: small_arm
         commands:
-           - source $NVM_DIR/nvm.sh && nvm use 20
+           - source $NVM_DIR/nvm.sh && nvm use 22
            - npm install
            - make compile test package
            - mkdir cwe-collector


### PR DESCRIPTION
currently while creating tags ps_spec.yml using nvm use 20 with that build is failing with ESM errors,corrected ps_spec.yml to use nvm use 22 nodejs when creating tag.
